### PR TITLE
Fix Default server on login

### DIFF
--- a/src/app/@core/framework/auth/djangopassword/djangopassword-strategy.ts
+++ b/src/app/@core/framework/auth/djangopassword/djangopassword-strategy.ts
@@ -155,6 +155,9 @@ export class DjangoPasswordAuthStrategy extends NbAuthStrategy {
     }
 
     protected registerServer(server): void {
+        if (server === undefined)
+            server = 'http://' + window.location.hostname + ':8000';
+
         let servers = JSON.parse(localStorage.getItem('cyborgServers'));
         if (servers !== null && typeof servers === 'object' && servers.indexOf(server) === -1 ) {
             servers.push(server);

--- a/src/app/@core/framework/auth/djangopassword/djangopassword-strategy.ts
+++ b/src/app/@core/framework/auth/djangopassword/djangopassword-strategy.ts
@@ -172,6 +172,9 @@ export class DjangoPasswordAuthStrategy extends NbAuthStrategy {
         if (data.hasOwnProperty('server')) {
             url = data.server + url;
             loginUrl = data.server + loginUrl;
+        } else {
+            url = 'http://' + window.location.hostname + ':8000' + url;
+            loginUrl = 'http://' + window.location.hostname + ':8000' + loginUrl;
         }
         const httpOptions = {
             headers: new HttpHeaders({ 'Access-Control-Allow-Origin': '*'})


### PR DESCRIPTION
This fix was primarily targeted at docker setup.  When a server is not specified during login it will generate a proper url (using port 8000) based on the current hostname.  I'm not able to test this with an installation method other than with docker.