### PR TITLE
Fixed submitting of policy form when "Keep x" is unchecked

### DIFF
--- a/src/app/@cyborg/components/forms/policy-form/policy-form.component.ts
+++ b/src/app/@cyborg/components/forms/policy-form/policy-form.component.ts
@@ -187,9 +187,9 @@ export class PolicyFormComponent implements OnInit {
   submit() {
     if (this.formPolicy.valid) {
       if (this.policyId !== 0) {
-        this.updatePolicy(this.formPolicy.value);
+        this.updatePolicy(this.formPolicy.getRawValue());
       } else {
-        this.createPolicy(this.formPolicy.value);
+        this.createPolicy(this.formPolicy.getRawValue());
       }
     }
   }


### PR DESCRIPTION
When "Keep Hourly" etc were saved with values, then the user tried to uncheck "Keep Hourly", the value would not update.  The cause of this is disabled inputs not being included in the api call.  When the keep_hourly, etc were not included in the api call they would not get updated.  The change in this commit forces all form values to be submitted (including disabled elements) therefore including the proper "null" values when the "keep x" is unchecked.